### PR TITLE
Readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Xatu is built upon the Armadillo C++ library for linear algebra, which is also b
 ### Ubuntu 22.04 LTS native and WSL
 Install the required libraries:
 ```
-sudo apt-get install libopenblas-dev liblapack-dev libarpack-dev libarmadillo-dev
+sudo apt-get install libopenblas-dev liblapack-dev libarpack2-dev libarmadillo-dev gfortran
 ```
 
 The library (```libxatu.a```) can be automatically built running the following command:

--- a/test/Makefile
+++ b/test/Makefile
@@ -8,7 +8,7 @@ ROOT_DIR := $(shell dirname $(PWD))
 INCLUDE = -I$(ROOT_DIR)/include
 
 # Libraries
-LIBS = -DARMA_DONT_USE_WRAPPER -L$(ROOT_DIR) -lxatu -larmadillo -lopenblas -llapack -fopenmp
+LIBS = -DARMA_DONT_USE_WRAPPER -L$(ROOT_DIR) -lxatu -larmadillo -lopenblas -llapack -fopenmp -larpack
 
 all: hbn_base hbn_davidson hbn_spin
 


### PR DESCRIPTION
The package name libarpack-dev is libarpack2-dev in ubuntu22 (Could not find the libarpack-dev)
gofortran doesn't comes pre-installed in ubuntu, although people might have installed it before.